### PR TITLE
Change mirror to kernel.org for cygwin

### DIFF
--- a/repos.conf.d/cygwin/repo.conf
+++ b/repos.conf.d/cygwin/repo.conf
@@ -1,3 +1,3 @@
-repo_url="rsync://mirror.team-cymru.org/cygwin"
+repo_url="rsync://mirrors.kernel.org/sourceware/cygwin/"
 repo_provider="rsync"
-dns_name="mirror.team-cymru.org/cygwin/"
+dns_name="mirrors.kernel.org/sourceware/cygwin/"


### PR DESCRIPTION
When looking at the team-cymru.org site it shows a sunset message.
We could use something like rsync://rsync.osuosl.org/cygwin/ instead
if that is preferred.