### PR TITLE
Updated Centos repo_url to correct error.

### DIFF
--- a/repos.conf.d/centos/repo.conf
+++ b/repos.conf.d/centos/repo.conf
@@ -1,3 +1,3 @@
-repo_url"rsync://centos.mirror.lstn.net/centos/"
+repo_url="rsync://centos.mirror.lstn.net/centos/"
 repo_provider="rsync"
 dns_name="mirror.centos.org/centos/"


### PR DESCRIPTION
Corrected error with a missing '=' for the repo_url.