### PR TITLE
Ub ppa fix and add gns3

### DIFF
--- a/repos.conf.d/ppa/provider.conf
+++ b/repos.conf.d/ppa/provider.conf
@@ -28,6 +28,8 @@ deb-amd64 http://ppa.launchpad.net/myriadrf/drivers-snapshots/ubuntu bionic main
 deb-i386  http://ppa.launchpad.net/myriadrf/drivers-snapshots/ubuntu bionic main
 deb-amd64 http://ppa.launchpad.net/myriadrf/gnuradio/ubuntu bionic main
 deb-i386  http://ppa.launchpad.net/myriadrf/gnuradio/ubuntu bionic main
+deb-amd64 http://ppa.launchpad.net/gns3/ppa/ubuntu bionic main
+deb-i386  http://ppa.launchpad.net/gns3/ppa/ubuntu bionic main
 
 # Xenial Xerus (16.04 LTS)
 deb-amd64 http://ppa.launchpad.net/bladerf/bladerf/ubuntu xenial main
@@ -40,6 +42,8 @@ deb-amd64 http://ppa.launchpad.net/myriadrf/drivers-snapshots/ubuntu xenial main
 deb-i386  http://ppa.launchpad.net/myriadrf/drivers-snapshots/ubuntu xenial main
 deb-amd64 http://ppa.launchpad.net/myriadrf/gnuradio/ubuntu xenial main
 deb-i386  http://ppa.launchpad.net/myriadrf/gnuradio/ubuntu xenial main
+deb-amd64 http://ppa.launchpad.net/gns3/ppa/ubuntu xenial main
+deb-i386  http://ppa.launchpad.net/gns3/ppa/ubuntu xenial main
 
 # Trusty "Crusty" Tahr (14.04 LTS)
 deb-amd64 http://ppa.launchpad.net/bladerf/bladerf/ubuntu trusty main
@@ -52,6 +56,8 @@ deb-amd64 http://ppa.launchpad.net/myriadrf/drivers-snapshots/ubuntu trusty main
 deb-i386  http://ppa.launchpad.net/myriadrf/drivers-snapshots/ubuntu trusty main
 deb-amd64 http://ppa.launchpad.net/myriadrf/gnuradio/ubuntu trusty main
 deb-i386  http://ppa.launchpad.net/myriadrf/gnuradio/ubuntu trusty main
+deb-amd64 http://ppa.launchpad.net/gns3/ppa/ubuntu trusty main
+deb-i386  http://ppa.launchpad.net/gns3/ppa/ubuntu trusty main
 
 # Precise Pangolin (12.04 LTS)
 deb-amd64 http://ppa.launchpad.net/bladerf/bladerf/ubuntu precise main
@@ -64,6 +70,8 @@ deb-amd64 http://ppa.launchpad.net/myriadrf/drivers-snapshots/ubuntu precise mai
 deb-i386  http://ppa.launchpad.net/myriadrf/drivers-snapshots/ubuntu precise main
 deb-amd64 http://ppa.launchpad.net/myriadrf/gnuradio/ubuntu precise main
 deb-i386  http://ppa.launchpad.net/myriadrf/gnuradio/ubuntu precise main
+deb-amd64 http://ppa.launchpad.net/gns3/ppa/ubuntu precise main
+deb-i386  http://ppa.launchpad.net/gns3/ppa/ubuntu precise main
 
 # Current Short-Term Support Releases
 
@@ -78,5 +86,7 @@ deb-amd64 http://ppa.launchpad.net/myriadrf/drivers-snapshots/ubuntu artful main
 deb-i386  http://ppa.launchpad.net/myriadrf/drivers-snapshots/ubuntu artful main
 deb-amd64 http://ppa.launchpad.net/myriadrf/gnuradio/ubuntu artful main
 deb-i386  http://ppa.launchpad.net/myriadrf/gnuradio/ubuntu artful main
+deb-amd64 http://ppa.launchpad.net/gns3/ppa/ubuntu artful main
+deb-i386  http://ppa.launchpad.net/gns3/ppa/ubuntu artful main
 
 clean http://ppa.launchpad.net/

--- a/repos.conf.d/ppa/provider.conf
+++ b/repos.conf.d/ppa/provider.conf
@@ -54,16 +54,16 @@ deb-amd64 http://ppa.launchpad.net/myriadrf/gnuradio/ubuntu trusty main
 deb-i386  http://ppa.launchpad.net/myriadrf/gnuradio/ubuntu trusty main
 
 # Precise Pangolin (12.04 LTS)
-deb-amd64 http://ppa.launchpad.net/bladerf/bladerf/ubuntu trusty main
-deb-i386  http://ppa.launchpad.net/bladerf/bladerf/ubuntu trusty main
-deb-amd64 http://ppa.launchpad.net/ettusresearch/uhd/ubuntu trusty main
-deb-i386  http://ppa.launchpad.net/ettusresearch/uhd/ubuntu trusty main
-deb-amd64 http://ppa.launchpad.net/myriadrf/drivers/ubuntu trusty main
-deb-i386  http://ppa.launchpad.net/myriadrf/drivers/ubuntu trusty main
-deb-amd64 http://ppa.launchpad.net/myriadrf/drivers-snapshots/ubuntu trusty main
-deb-i386  http://ppa.launchpad.net/myriadrf/drivers-snapshots/ubuntu trusty main
-deb-amd64 http://ppa.launchpad.net/myriadrf/gnuradio/ubuntu trusty main
-deb-i386  http://ppa.launchpad.net/myriadrf/gnuradio/ubuntu trusty main
+deb-amd64 http://ppa.launchpad.net/bladerf/bladerf/ubuntu precise main
+deb-i386  http://ppa.launchpad.net/bladerf/bladerf/ubuntu precise main
+deb-amd64 http://ppa.launchpad.net/ettusresearch/uhd/ubuntu precise main
+deb-i386  http://ppa.launchpad.net/ettusresearch/uhd/ubuntu precise main
+deb-amd64 http://ppa.launchpad.net/myriadrf/drivers/ubuntu precise main
+deb-i386  http://ppa.launchpad.net/myriadrf/drivers/ubuntu precise main
+deb-amd64 http://ppa.launchpad.net/myriadrf/drivers-snapshots/ubuntu precise main
+deb-i386  http://ppa.launchpad.net/myriadrf/drivers-snapshots/ubuntu precise main
+deb-amd64 http://ppa.launchpad.net/myriadrf/gnuradio/ubuntu precise main
+deb-i386  http://ppa.launchpad.net/myriadrf/gnuradio/ubuntu precise main
 
 # Current Short-Term Support Releases
 


### PR DESCRIPTION
Update branch to correct an error in the precise section of the ppa apt-mirror configuration.  Also added gns3 to the ppa apt-mirror configuration.