### PR TITLE
Updated debian to use cdn

### DIFF
--- a/repos.conf.d/debian/provider.conf
+++ b/repos.conf.d/debian/provider.conf
@@ -15,35 +15,35 @@ set http_proxy        127.0.0.1:3128
 set proxy_user        user
 set proxy_password    password
 
-deb-amd64 http://deb.debian.org/debian wheezy main contrib non-free
-deb-amd64 http://deb.debian.org/debian wheezy-updates main contrib non-free
-deb-amd64 http://deb.debian.org/debian-security wheezy/updates main contrib non-free
-deb-amd64 http://deb.debian.org/debian stretch main contrib non-free
-deb-amd64 http://deb.debian.org/debian stretch-updates main contrib non-free
-deb-amd64 http://deb.debian.org/debian-security stretch/updates main contrib non-free
-deb-amd64 http://deb.debian.org/debian jessie main contrib non-free
-deb-amd64 http://deb.debian.org/debian jessie-updates main contrib non-free
-deb-amd64 http://deb.debian.org/debian-security jessie/updates main contrib non-free
+deb-amd64 http://cdn-fastly.deb.debian.org/debian wheezy main contrib non-free
+deb-amd64 http://cdn-fastly.deb.debian.org/debian wheezy-updates main contrib non-free
+deb-amd64 http://cdn-fastly.deb.debian.org/debian-security wheezy/updates main contrib non-free
+deb-amd64 http://cdn-fastly.deb.debian.org/debian stretch main contrib non-free
+deb-amd64 http://cdn-fastly.deb.debian.org/debian stretch-updates main contrib non-free
+deb-amd64 http://cdn-fastly.deb.debian.org/debian-security stretch/updates main contrib non-free
+deb-amd64 http://cdn-fastly.deb.debian.org/debian jessie main contrib non-free
+deb-amd64 http://cdn-fastly.deb.debian.org/debian jessie-updates main contrib non-free
+deb-amd64 http://cdn-fastly.deb.debian.org/debian-security jessie/updates main contrib non-free
 
-deb-i386  http://deb.debian.org/debian wheezy main contrib non-free
-deb-i386  http://deb.debian.org/debian wheezy-updates main contrib non-free
-deb-i386  http://deb.debian.org/debian-security wheezy/updates main contrib non-free
-deb-i386  http://deb.debian.org/debian stretch main contrib non-free
-deb-i386  http://deb.debian.org/debian stretch-updates main contrib non-free
-deb-i386  http://deb.debian.org/debian-security stretch/updates main contrib non-free
-deb-i386  http://deb.debian.org/debian jessie main contrib non-free
-deb-i386  http://deb.debian.org/debian jessie-updates main contrib non-free
-deb-i386  http://deb.debian.org/debian-security jessie/updates main contrib non-free
+deb-i386  http://cdn-fastly.deb.debian.org/debian wheezy main contrib non-free
+deb-i386  http://cdn-fastly.deb.debian.org/debian wheezy-updates main contrib non-free
+deb-i386  http://cdn-fastly.deb.debian.org/debian-security wheezy/updates main contrib non-free
+deb-i386  http://cdn-fastly.deb.debian.org/debian stretch main contrib non-free
+deb-i386  http://cdn-fastly.deb.debian.org/debian stretch-updates main contrib non-free
+deb-i386  http://cdn-fastly.deb.debian.org/debian-security stretch/updates main contrib non-free
+deb-i386  http://cdn-fastly.deb.debian.org/debian jessie main contrib non-free
+deb-i386  http://cdn-fastly.deb.debian.org/debian jessie-updates main contrib non-free
+deb-i386  http://cdn-fastly.deb.debian.org/debian-security jessie/updates main contrib non-free
 
-deb-src http://deb.debian.org/debian wheezy main contrib non-free
-deb-src http://deb.debian.org/debian wheezy-updates main contrib non-free
-deb-src http://deb.debian.org/debian-security wheezy/updates main contrib non-free
-deb-src http://deb.debian.org/debian stretch main contrib non-free
-deb-src http://deb.debian.org/debian stretch-updates main contrib non-free
-deb-src http://deb.debian.org/debian-security stretch/updates main contrib non-free
-deb-src http://deb.debian.org/debian jessie main contrib non-free
-deb-src http://deb.debian.org/debian jessie-updates main contrib non-free
-deb-src http://deb.debian.org/debian-security jessie/updates main contrib non-free
+deb-src http://cdn-fastly.deb.debian.org/debian wheezy main contrib non-free
+deb-src http://cdn-fastly.deb.debian.org/debian wheezy-updates main contrib non-free
+deb-src http://cdn-fastly.deb.debian.org/debian-security wheezy/updates main contrib non-free
+deb-src http://cdn-fastly.deb.debian.org/debian stretch main contrib non-free
+deb-src http://cdn-fastly.deb.debian.org/debian stretch-updates main contrib non-free
+deb-src http://cdn-fastly.deb.debian.org/debian-security stretch/updates main contrib non-free
+deb-src http://cdn-fastly.deb.debian.org/debian jessie main contrib non-free
+deb-src http://cdn-fastly.deb.debian.org/debian jessie-updates main contrib non-free
+deb-src http://cdn-fastly.deb.debian.org/debian-security jessie/updates main contrib non-free
 
-clean http://deb.debian.org/debian
-clean http://deb.debian.org/debian-security
+clean http://cdn-fastly.deb.debian.org/debian
+clean http://cdn-fastly.deb.debian.org/debian-security


### PR DESCRIPTION
Updated the debian provider.conf to use cdn-fastly.deb.debian.org url instead of the deb.debian.org.