### PR TITLE
Ub fix apt mirror configs

### DIFF
--- a/repos.conf.d/debian/provider.conf
+++ b/repos.conf.d/debian/provider.conf
@@ -1,4 +1,5 @@
-set base_path         /mirror1/debian/
+# base_path will be dynamically set during sync
+#set base_path         /mirror1/debian/
 set mirror_path       $base_path/mirror
 set skel_path         $base_path/skel
 set var_path          $base_path/var

--- a/repos.conf.d/kali/provider.conf
+++ b/repos.conf.d/kali/provider.conf
@@ -1,5 +1,6 @@
+# base_path will be dynamically set during sync
 # base_path should always be set to "/var/spool/mirror/${repo_name}
-set base_path         /mirror1/kali
+#set base_path         /mirror1/kali
 
 # mirror_path should match the ${mirror_tld} in bashellite.conf, with ${repo_name} appended
 set mirror_path       $base_path/mirror

--- a/repos.conf.d/postgresql-apt/provider.conf
+++ b/repos.conf.d/postgresql-apt/provider.conf
@@ -1,4 +1,5 @@
-set base_path         /mirror1/postgresql-apt
+# base_path will be dynamically set during sync
+#set base_path         /mirror1/postgresql-apt
 set mirror_path       $base_path/mirror
 set skel_path         $base_path/skel
 set var_path          $base_path/var

--- a/repos.conf.d/ppa/provider.conf
+++ b/repos.conf.d/ppa/provider.conf
@@ -1,4 +1,5 @@
-set base_path         /mirror1/ppa
+# base_path will be dynamically set during sync
+#set base_path         /mirror1/ppa
 set mirror_path       $base_path/mirror
 set skel_path         $base_path/skel
 set var_path          $base_path/var

--- a/repos.conf.d/raspbian/provider.conf
+++ b/repos.conf.d/raspbian/provider.conf
@@ -1,4 +1,5 @@
-set base_path         /mirror1/raspbian
+# base_path will be dynamically set during sync
+#set base_path         /mirror1/raspbian
 set mirror_path       $base_path/mirror
 set skel_path         $base_path/skel
 set var_path          $base_path/var

--- a/repos.conf.d/ubuntu/provider.conf
+++ b/repos.conf.d/ubuntu/provider.conf
@@ -1,4 +1,5 @@
-set base_path         /mirror1/ubuntu/
+# base_path will be dynamically set during sync
+#set base_path         /mirror1/ubuntu/
 set mirror_path       $base_path/mirror
 set skel_path         $base_path/skel
 set var_path          $base_path/var

--- a/sample-apt-mirror-provider.conf
+++ b/sample-apt-mirror-provider.conf
@@ -1,17 +1,18 @@
 # This sample provider.conf file uses the kali repo as an example
 
+# base_path will be dynamically set during sync
 # base_path should always be set to "/var/spool/mirror/${repo_name}
-set base_path         /var/spool/mirror/kali
+#set base_path         /mirror1/kali
 
 # mirror_path should match the ${mirror_tld} in bashellite.conf, with ${repo_name} appended
-set mirror_path       /mirror1/kali
+set mirror_path       $base_path/mirror
 
 # All other "set" settings in the config portion of the file should be apt-mirror provided defaults
 # A sample default reference config is provided in /etc/apt/mirror.list upon installation of apt-mirror
 set skel_path         $base_path/skel
 set var_path          $base_path/var
 set postmirror_script $var_path/postmirror.sh
-set defaultarch       x86_64
+set defaultarch       amd64
 set run_postmirror    0
 set nthreads          20
 set limit_rate        100m


### PR DESCRIPTION
This update corrects apt-mirror provider.conf files to no longer set the base_path variable.  That variable will now be dynamically set during each sync.