### PR TITLE
Temporarily removing older ubuntu images.

### DIFF
--- a/repos.conf.d/images__ubuntu/provider.conf
+++ b/repos.conf.d/images__ubuntu/provider.conf
@@ -1,13 +1,3 @@
-r releases/lucid/release-20150427/ubuntu-10.04-server-cloudimg-i386.tar.gz
-r releases/lucid/release-20150427/ubuntu-10.04-server-cloudimg-amd64.tar.gz
-r releases/lucid/release-20150427/ubuntu-10.04-server-cloudimg-amd64-disk1.img
-r releases/lucid/release-20150427/ubuntu-10.04-server-cloudimg-i386-disk1.img
-r releases/lucid/release-20150427/*SUMS*
-r releases/precise/release-20170502/ubuntu-12.04-server-cloudimg-amd64-disk1.img
-r releases/precise/release-20170502/ubuntu-12.04-server-cloudimg-amd64.tar.gz
-r releases/precise/release-20170502/ubuntu-12.04-server-cloudimg-i386-disk1.img
-r releases/precise/release-20170502/ubuntu-12.04-server-cloudimg-i386.tar.gz
-r releases/precise/release-20170502/*SUMS*
 r trusty/current/trusty-server-cloudimg-amd64-disk1.img
 r trusty/current/trusty-server-cloudimg-amd64-lxd.tar.xz
 r trusty/current/trusty-server-cloudimg-amd64.tar.gz


### PR DESCRIPTION
Due to how wget works with recursion and redirects, need to move older
ubuntu images to another repo that pulls from the redirected URL.