### PR TITLE
Adding temporary repo for older ubuntu cloud images.

### DIFF
--- a/repos.conf.d/images__ubuntu-archive/provider.conf
+++ b/repos.conf.d/images__ubuntu-archive/provider.conf
@@ -1,0 +1,10 @@
+r releases/lucid/release-20150427/ubuntu-10.04-server-cloudimg-i386.tar.gz
+r releases/lucid/release-20150427/ubuntu-10.04-server-cloudimg-amd64.tar.gz
+r releases/lucid/release-20150427/ubuntu-10.04-server-cloudimg-amd64-disk1.img
+r releases/lucid/release-20150427/ubuntu-10.04-server-cloudimg-i386-disk1.img
+r releases/lucid/release-20150427/*SUMS*
+r releases/precise/release-20170502/ubuntu-12.04-server-cloudimg-amd64-disk1.img
+r releases/precise/release-20170502/ubuntu-12.04-server-cloudimg-amd64.tar.gz
+r releases/precise/release-20170502/ubuntu-12.04-server-cloudimg-i386-disk1.img
+r releases/precise/release-20170502/ubuntu-12.04-server-cloudimg-i386.tar.gz
+r releases/precise/release-20170502/*SUMS*

--- a/repos.conf.d/images__ubuntu-archive/repo.conf
+++ b/repos.conf.d/images__ubuntu-archive/repo.conf
@@ -1,0 +1,3 @@
+repo_url="http://cloud-images-archive.ubuntu.com/"
+repo_provider="wget"
+dns_name="cloud-images.ubuntu.com"


### PR DESCRIPTION
Do to wget not being able to redirect when doing recursive requests,
need to add a temporary repo to handle older ubuntu cloud images.