### PR TITLE
Add centos cloud images repo

### DIFF
--- a/repos.conf.d/images__centos/provider.conf
+++ b/repos.conf.d/images__centos/provider.conf
@@ -1,0 +1,1 @@
+r centos/7/images/CentOS-7-x86_64-GenericCloud-*.raw.tar.gz

--- a/repos.conf.d/images__centos/repo.conf
+++ b/repos.conf.d/images__centos/repo.conf
@@ -1,0 +1,3 @@
+repo_url="http://cloud.centos.org/"
+repo_provider="wget"
+dns_name="cloud.centos.org"


### PR DESCRIPTION
Re-added centos cloud images repo.

Previously, the repo was removed due to incorrectly thinking the cloud images were contained in the centos repo.